### PR TITLE
Adds test cases for UserAccount View

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -111,3 +111,24 @@ class UserAccountViewTest(TestCase):
         response = view(request)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @pytest.mark.django_db
+    def test_update_user_account_view(self):
+        """Create request object using factory"""
+        request = self.factory.patch(
+            reverse("Retrieve Update Profile"),
+            data={"username": "updated_username"},
+            content_type="application/json",
+        )
+
+        """Authenticating the request"""
+        force_authenticate(
+            request=request, user=self.user, token=self.auth_transaction.token
+        )
+
+        """Creates and sets up the RetrieveUpdateUserAccountView"""
+        view = RetrieveUpdateUserAccountView.as_view()
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.user.username, "updated_username")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from model_bakery import baker
 from rest_framework import status
+from rest_framework.test import force_authenticate
 
 from drf_user.models import AuthTransaction
 from drf_user.models import User
@@ -94,3 +95,19 @@ class UserAccountViewTest(TestCase):
         view.setup(request)
 
         self.assertEqual(view.get_object(), self.user)
+
+    @pytest.mark.django_db
+    def test_get_user_account_view(self):
+        """Create request object using factory"""
+        request = self.factory.get(reverse("Retrieve Update Profile"))
+
+        """Authenticating the request"""
+        force_authenticate(
+            request=request, user=self.user, token=self.auth_transaction.token
+        )
+
+        """Creates and sets up the RetrieveUpdateUserAccountView"""
+        view = RetrieveUpdateUserAccountView.as_view()
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -111,6 +111,7 @@ class UserAccountViewTest(TestCase):
         response = view(request)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["username"], self.user.username)
 
     @pytest.mark.django_db
     def test_update_user_account_view(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,11 +2,14 @@
 import pytest
 from django.test import Client
 from django.test import TestCase
+from django.test.client import RequestFactory
 from django.urls import reverse
 from model_bakery import baker
 from rest_framework import status
 
+from drf_user.models import AuthTransaction
 from drf_user.models import User
+from drf_user.views import RetrieveUpdateUserAccountView
 
 
 class LoginViewTest(TestCase):
@@ -50,3 +53,44 @@ class LoginViewTest(TestCase):
             reverse("Login"), data={"username": "user", "password": "pass1234"}
         )
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+
+class UserAccountViewTest(TestCase):
+    """User Account View Test"""
+
+    def setUp(self) -> None:
+        """Create Client object to call the API"""
+        self.factory = RequestFactory()
+
+        """Create User object using model_bakery"""
+        self.user = baker.make(
+            "drf_user.User",
+            username="user",
+            email="user@email.com",
+            mobile=1234569877,
+        )
+
+        """Create auth_transaction object using model_bakery"""
+        self.auth_transaction = baker.make(
+            "drf_user.AuthTransaction",
+            created_by=self.user,
+        )
+
+    @pytest.mark.django_db
+    def test_object_created(self):
+        """Check if AuthTransaction object created or not"""
+        assert AuthTransaction.objects.count() == 1
+
+    @pytest.mark.django_db
+    def test_get_object_method(self):
+        """Create request object using factory"""
+        request = self.factory.get(reverse("Retrieve Update Profile"))
+
+        """Simulating that self.user has made the request"""
+        request.user = self.user
+
+        """Creates and sets up the RetrieveUpdateUserAccountView"""
+        view = RetrieveUpdateUserAccountView()
+        view.setup(request)
+
+        self.assertEqual(view.get_object(), self.user)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -60,7 +60,7 @@ class UserAccountViewTest(TestCase):
     """User Account View Test"""
 
     def setUp(self) -> None:
-        """Create Client object to call the API"""
+        """Create RequestFactory object to call the API"""
         self.factory = RequestFactory()
 
         """Create User object using model_bakery"""


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
Adds test cases for `RetrieveUpdateUserAccountView`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `drf-user` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [ ] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.md`.
    - [ ] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
NONE

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
