### PR TITLE
makes check_unique function shorter

### DIFF
--- a/drf_user/utils.py
+++ b/drf_user/utils.py
@@ -58,10 +58,7 @@ def check_unique(prop, value):
     True
     """
     user = User.objects.extra(where=[prop + " = '" + value + "'"])
-    if user.count() != 0:
-        return False
-    else:
-        return True
+    return user.count() == 0
 
 
 def generate_otp(prop, value):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+"""Tests for drf_user/utils.py module"""
+import pytest
+from django.test import TestCase
+from model_bakery import baker
+
+from drf_user import utils as utils
+from drf_user.models import User
+
+
+class TestCheckUnique(TestCase):
+    """check_unique test"""
+
+    def setUp(self) -> None:
+        """Create user object using model_bakery"""
+        self.user = baker.make(
+            "drf_user.User",
+            email="user@email.com",
+        )
+
+    @pytest.mark.django_db
+    def test_object_created(self):
+        """Check if User object created or not"""
+        self.assertEqual(User.objects.count(), 1)
+
+    @pytest.mark.django_db
+    def test_check_non_unique(self):
+        """Check if the user is non-unique"""
+        self.assertTrue(utils.check_unique("email", "user1@email.com"))
+
+    @pytest.mark.django_db
+    def test_check_unique(self):
+        """Check if the user is unique"""
+        self.assertFalse(utils.check_unique("email", "user@email.com"))


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
makes `check_unique` function a bit shorter

## Motivation and Context
Have done this change so as to make code shorter and a bit more readable

## Have you tested this? If so, how?
Yes, I have added relevant tests for the change.

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.md`.
    - [ ] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
NONE

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
