### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.11
-django-filter==2.3.0
+django-filter==2.4.0
 djangorestframework>=3.8.0
 djangorestframework-jwt==1.11.0
 drfaddons>=0.1.0


### PR DESCRIPTION
Django-filter was an old version. Updated to 2.4.0.

# I updated Requirements.txt

## Description
Django-filters version was old and giving an ImportError, so I updated it from 2.3.0 to 2.4.0.

## Have you tested this? If so, how?
I have tested it and it worked. I installed it using pip again with version, 2.4.0. Django-filters version 2.3.0 works with older django versions.