### PR TITLE
Fix the setup step in make livehtml for sphnix autobuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,7 +24,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html"
 
 livehtml:
-	sphinx-autobuild -p $(PORT) -b html $(SOURCEDIR) $(BUILDDIR)/html $(O)
+	sphinx-autobuild --port $(PORT) -b html $(SOURCEDIR) $(BUILDDIR)/html $(O)
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,6 @@ pytest
 pytest-cov
 pytest-django
 sphinx
+sphinx-autobuild==2021.3.14
 sphinxcontrib_httpdomain
 tox


### PR DESCRIPTION
## Description
Fixing setup step in `make livehtml,` one of the argument `-p` is deprecated so changing it with the latest one `--port`

## Motivation and Context
This helps fix the setup step.

## Have you tested this? If so, how?
Yes, it works.

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/3849885/134001218-2bd6f07b-b3c9-4aa5-9fda-5590fa9d3958.png">


## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.md`.
    - [ ] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

### Issue
Resolves #115