### PR TITLE
Fix #123 : updated Makefile to support windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,16 +152,6 @@ files for some of their features (e.g. automatically picking up the
 
 ## Local Development Environment
 
-Steps to Install make for windows
-
-- Install chocolatey from [here](https://chocolatey.org/install).
-
-- And then run following command
-
-```sh
-$ choco install make
-```
-
 <!-- You can (and should) run our test suite using [tox](https://tox.readthedocs.io/). However, you’ll probably want a more traditional environment as well. We highly recommend to develop using the latest Python 3 release because `interrogate` tries to take advantage of modern features whenever possible. -->
 
 First create a [virtual environment](https://virtualenv.pypa.io/). It’s out of
@@ -189,6 +179,12 @@ Change into the newly created directory and **after activating your virtual
 environment** install an editable version of `drf-user` along with its tests,
 docs requirements and to avoid committing code that violates our style guide, we
 use [pre-commit](https://pre-commit.com/) hooks:
+
+Note : For **windows** users, please refer this link to install choco [here](https://chocolatey.org/install) and then use following command to setup make
+
+```sh
+$ choco install make
+```
 
 ```sh
 (env) $ cd drf-user

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,16 @@ files for some of their features (e.g. automatically picking up the
 
 ## Local Development Environment
 
+Steps to Install make for windows
+
+- Install chocolatey from [here](https://chocolatey.org/install).
+
+- And then run following command
+
+```sh
+$ choco install make
+```
+
 <!-- You can (and should) run our test suite using [tox](https://tox.readthedocs.io/). However, you’ll probably want a more traditional environment as well. We highly recommend to develop using the latest Python 3 release because `interrogate` tries to take advantage of modern features whenever possible. -->
 
 First create a [virtual environment](https://virtualenv.pypa.io/). It’s out of

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: clean-pyc clean-build docs clean
 
-VENV = venv
-PYTHON=$(VENV)/bin/python
+VIRTUALENV = virtualenv --python=python3
+PYTHON = $(VENV)/bin/python
+VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 
 # make it work on windows too
 ifeq ($(OS), Windows_NT)
+	VENV = venv
     PYTHON=$(VENV)/Scripts/python
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 .PHONY: clean-pyc clean-build docs clean
 
-VIRTUALENV = virtualenv --python=python3
-PYTHON = $(VENV)/bin/python
-VENV := $(shell echo $${VIRTUAL_ENV-.venv})
+VENV = venv
+PYTHON=$(VENV)/bin/python
+
+# make it work on windows too
+ifeq ($(OS), Windows_NT)
+    PYTHON=$(VENV)/Scripts/python
+endif
 
 TEST_FLAGS=--verbosity=2
 COVER_FLAGS=--source=drf_user


### PR DESCRIPTION
## Description
Added condition in Makefile to handle for windows environment

## Motivation and Context
Resolves #123

## Have you tested this? If so, how?
Yes i have tested this.
<img width="574" alt="make_test_ss" src="https://user-images.githubusercontent.com/18002346/139418030-f1c6fa2d-0f40-473e-8f8f-f4a4decf58fb.PNG">


## Checklist for PR author(s)
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [x] Updates to documentation:
    - [x] Document any relevant additions/changes in `README.md`.
    - [x] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [x] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

label=EPAM_INDIA_OSS_CONTRIBUTORS