### PR TITLE
we need to set_password after save the user otherwise it'll save the raw_password in db.

### DIFF
--- a/drf_user/views.py
+++ b/drf_user/views.py
@@ -341,7 +341,9 @@ class OTPLoginView(APIView):
                 otp_obj_email.save()
                 message["email"] = {"otp": _("OTP has been sent successfully.")}
             else:
-                message["email"] = {"otp": _(f'OTP sending failed {sentotp_email["message"]}')}
+                message["email"] = {
+                    "otp": _("OTP sending failed {}".format(sentotp_email["message"]))
+                }
 
             if sentotp_mobile["success"]:
                 otp_obj_mobile.send_counter += 1
@@ -349,9 +351,8 @@ class OTPLoginView(APIView):
                 message["mobile"] = {"otp": _("OTP has been sent successfully.")}
             else:
                 message["mobile"] = {
-                    "otp": _(f'OTP sending failed {sentotp_mobile["message"]}')
+                    "otp": _("OTP sending failed {}".format(sentotp_mobile["message"]))
                 }
-
 
             if sentotp_email["success"] or sentotp_mobile["success"]:
                 curr_status = status.HTTP_201_CREATED

--- a/drf_user/views.py
+++ b/drf_user/views.py
@@ -261,14 +261,13 @@ class RetrieveUpdateUserAccountView(RetrieveUpdateAPIView):
     def update(self, request, *args, **kwargs):
         """Updates user's password"""
 
-        response = super(RetrieveUpdateUserAccountView, self).update(
-            request, *args, **kwargs
-        )
-        # we need to set_password after save the user otherwise it'll save the raw_password in db.
         if "password" in request.data.keys():
             self.request.user.set_password(request.data["password"])
             self.request.user.save()
-        return response
+
+        return super(RetrieveUpdateUserAccountView, self).update(
+            request, *args, **kwargs
+        )
 
 
 class OTPLoginView(APIView):

--- a/drf_user/views.py
+++ b/drf_user/views.py
@@ -261,13 +261,14 @@ class RetrieveUpdateUserAccountView(RetrieveUpdateAPIView):
     def update(self, request, *args, **kwargs):
         """Updates user's password"""
 
+        response = super(RetrieveUpdateUserAccountView, self).update(
+            request, *args, **kwargs
+        )
+        # we need to set_password after save the user otherwise it'll save the raw_password in db.
         if "password" in request.data.keys():
             self.request.user.set_password(request.data["password"])
             self.request.user.save()
-
-        return super(RetrieveUpdateUserAccountView, self).update(
-            request, *args, **kwargs
-        )
+        return response
 
 
 class OTPLoginView(APIView):


### PR DESCRIPTION
# Hey, I just made a Pull Request!

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." and -->
<!--- "I ran `drf-user` with these changes over some code and it works for me." -->

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Changes are covered by unit tests (no major decrease in code coverage %).
- [ ] All tests pass.
- [ ] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.md`.
    - [ ] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
