### PR TITLE
Fix: unsafe raw SQL in check_unique()

### DIFF
--- a/drf_user/utils.py
+++ b/drf_user/utils.py
@@ -93,7 +93,7 @@ def check_unique(prop: str, value: str) -> bool:
     >>> print(check_unique('email', 'test@testing.com'))
     True
     """
-    user = User.objects.extra(where=[prop + " = '" + value + "'"])
+    user = User.objects.filter(**{prop: value})
     return user.count() == 0
 
 

--- a/drf_user/utils.py
+++ b/drf_user/utils.py
@@ -93,8 +93,7 @@ def check_unique(prop: str, value: str) -> bool:
     >>> print(check_unique('email', 'test@testing.com'))
     True
     """
-    user = User.objects.filter(**{prop: value})
-    return user.count() == 0
+    return not User.objects.filter(**{prop: value}).exists()
 
 
 def generate_otp(prop: str, value: str) -> OTPValidation:


### PR DESCRIPTION
## Description
Replaces User.objects.extra() with User.objects.filter() in check_unique() utility function.
The extra() method with raw string construction is unnecessary here since prop is already restricted to known field names. Using the ORM's filter() with keyword argument unpacking is cleaner and safer.

## Motivation and Context
The check_unique() function was using User.objects.extra() with raw string concatenation to build a WHERE clause. this pattern is unsafe as it does not use parameterized queries.

## Have you tested this? If so, how?
executed existing test suite and all test passed

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %).
- [x] All tests pass.
- [x] Docstring coverage is **100%** via `interrogate drf_user` (I mean, we _should_ set a good example :smile:).
- [ ] Updates to documentation:
    - [ ] Document any relevant additions/changes in `README.md`.
    - [ ] Manually update **both** the `README.md` _and_ `docs/index.rst` for any new changes.
    - [ ] Any changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in the project's [``__init__.py``](https://github.com/101loop/drf-user/blob/master/drf_user/__init__.py) file.

## Release note
<!--  If your change is non-trivial (e.g. more than a fixed typo in docs, or updated tests), please write a suggested release note for us to include in `docs/changelog.rst` (we may edit it a bit).

1. Enter your release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ". Please write it in the imperative.
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->

## Summary by Sourcery

Bug Fixes:
- Prevent potential SQL injection by replacing raw WHERE clause construction in check_unique() with a parameterized ORM filter query.

## Summary by Sourcery

Bug Fixes:
- Prevent potential SQL injection in check_unique() by using a parameterized ORM filter instead of constructing a raw WHERE clause.